### PR TITLE
Fix delete time entry

### DIFF
--- a/src/payloads.js
+++ b/src/payloads.js
@@ -14,3 +14,10 @@ export const FETCH_TIME_ENTRIES_PAYLOAD = (consultantId, tableName, start_time, 
     ^ORDERBYstart_time`,
     sysparm_fields: 'date,sys_id,time_adjustment, project.sys_id, project.client.sys_id, adjustment_direction'
 })
+
+export const FETCH_TIME_ENTRIES_FOR_DELETE_PAYLOAD = (consultantId, tableName, project) => ({
+    tableName,
+    sysparm_query: `consultant=${consultantId}^project=${project}^dateONToday@javascript:gs.beginningOfToday()@javascript:gs.endOfToday()
+    ^ORDERBYstart_time`,
+    sysparm_fields: 'date,sys_id,time_adjustment, project.sys_id, project.client.sys_id, adjustment_direction'
+})

--- a/src/project-item/index.js
+++ b/src/project-item/index.js
@@ -101,6 +101,7 @@ const view = (state, { dispatch, updateState}) => {
             </div>
             <div className='project-notes details-icon'>
                 {timestamps.map((stamp, i) => {
+                    const timestampLength = timestamps.length;
                     if (!showDetail && active && (i > 0)) return
                     if (!showDetail && !active) return
                     return (
@@ -113,6 +114,8 @@ const view = (state, { dispatch, updateState}) => {
                             timestampTable={timestampTable}
                             consultantId={consultantId}
                             selectedDay={selectedDay}
+                            timeEntryTable={timeEntryTable}
+                            timestampLength={timestampLength}
                         />
                     );
                 })}

--- a/src/project-item/index.js
+++ b/src/project-item/index.js
@@ -1,7 +1,7 @@
 import { createCustomElement } from '@servicenow/ui-core';
 import { snabbdom } from '@servicenow/ui-renderer-snabbdom';
 import { Timestamp } from '../x-esg-timer-container/components/Timestamp';
-import { FETCH_CONSULTANT_TIMESTAMPS_PAYLOAD } from '../payloads';
+import { FETCH_CONSULTANT_TIMESTAMPS_PAYLOAD, FETCH_TIME_ENTRIES_FOR_DELETE_PAYLOAD} from '../payloads';
 import { msToString, getSnDayBounds } from '../helpers';
 import { isToday } from 'date-fns';
 import styles from './styles.scss';
@@ -30,6 +30,7 @@ const view = (state, { dispatch, updateState}) => {
             proj,
             projectMap,
             selectedDay,
+            timeEntryTable
 
         } = properties;
 
@@ -45,7 +46,11 @@ const view = (state, { dispatch, updateState}) => {
 
     const handleDeleteProject = (e, projectToBeDeleted) => {
         e.preventDefault();
+
         if (confirm("Click OK to remove this project") == true) {
+
+            dispatch('FETCH_TIME_ENTRIES_FOR_DELETE', FETCH_TIME_ENTRIES_FOR_DELETE_PAYLOAD(consultantId, timeEntryTable, projectToBeDeleted.sys_id))
+
             projectToBeDeleted.timestamps.forEach(timestamp => {
                 dispatch('DELETE_PROJECT_TIMESTAMPS', {
                     tableName: timestampTable,
@@ -130,6 +135,7 @@ createCustomElement('project-item', {
 		consultantId: {default: ''},
 		proj: {default: {}},
 		projectMap: {default: []},
-		selectedDay: {default: ''}
+		selectedDay: {default: ''},
+        timeEntryTable: {default: ''}
 	}
 });

--- a/src/x-esg-timer-container/actionHandlers.js
+++ b/src/x-esg-timer-container/actionHandlers.js
@@ -27,9 +27,9 @@ export default {
         errorActionType: 'LOG_ERROR',
     }),
     //Testing Timer stoppers,
-    'DELETE_PROJECT_TIMESTAMPS': createHttpEffect(`api/now/table/x_esg_one_delivery_timestamp/:id`, {
+    'DELETE_PROJECT_TIMESTAMPS': createHttpEffect(`api/now/table/:tableName/:id`, {
         method: 'DELETE',
-        pathParams: [ 'id'],
+        pathParams: ['tableName', 'id'],
         startActionType: 'TEST_START',
         successActionType: 'LOG_RESULT',
         errorActionType: 'LOG_ERROR'
@@ -85,4 +85,23 @@ export default {
     'SET_CONSULTANT_TIMESTAMPS': ({action, updateState}) => {
         updateState({projectMap: buildProjectMap(action.payload.result)});
     },
+    'FETCH_TIME_ENTRIES_FOR_DELETE': createHttpEffect('api/now/table/:tableName', {
+        method: 'GET',
+        pathParams: ['tableName'],
+        queryParams: ['sysparm_query', 'sysparm_fields'],
+        startActionType: 'TEST_START',
+        successActionType: 'DELETE_TIME_ENTRIES',
+        errorActionType: 'LOG_ERROR',
+    }),
+    'DELETE_TIME_ENTRIES': ({action, dispatch}) => {
+        console.log('TIME ENTRY TO BE DELETED', action.payload);
+        const entriesToBeDeleted = action.payload.result;
+
+        entriesToBeDeleted.map(entry => {
+            dispatch('DELETE_PROJECT_TIMESTAMPS', {
+                tableName: "x_esg_one_delivery_time_entry",
+                id: entry.sys_id,
+            });
+        })
+    }
 } 

--- a/src/x-esg-timer-container/components/Timestamp.js
+++ b/src/x-esg-timer-container/components/Timestamp.js
@@ -1,5 +1,5 @@
 import { hhmmToSnTime, getUTCTime, toSnTime, getSnDayBounds } from '../../helpers';
-import { FETCH_CONSULTANT_TIMESTAMPS_PAYLOAD } from '../../payloads';
+import { FETCH_CONSULTANT_TIMESTAMPS_PAYLOAD, FETCH_TIME_ENTRIES_FOR_DELETE_PAYLOAD } from '../../payloads';
 import { format } from 'date-fns';
 
 export const Timestamp = ({ 
@@ -9,7 +9,9 @@ export const Timestamp = ({
                             dispatch,
                             timestampTable,
                             consultantId,
-                            selectedDay}) => {
+                            selectedDay, 
+                            timeEntryTable,
+                            timestampLength}) => {
 
     const {note, start_time, end_time, sys_id} = stamp;                                     
     const localTimes = {start: format(getUTCTime(start_time), 'HH:mm')}
@@ -18,7 +20,13 @@ export const Timestamp = ({
 
     const handleDeleteTimestamp = (e, sys_id) => {
         e.preventDefault();
+        
         if (confirm("Click OK to remove this timestamp") == true) {
+
+            if(timestampLength == 1) {
+                dispatch('FETCH_TIME_ENTRIES_FOR_DELETE', FETCH_TIME_ENTRIES_FOR_DELETE_PAYLOAD(consultantId, timeEntryTable, stamp['project.sys_id']))
+            }
+                
             dispatch('DELETE_PROJECT_TIMESTAMPS', {
                 tableName: timestampTable,
                 id: sys_id,

--- a/src/x-esg-timer-container/view.js
+++ b/src/x-esg-timer-container/view.js
@@ -61,6 +61,7 @@ export const view = (state, {dispatch, updateState}) => {
                                 selectedDay={selectedDay}
                                 projectMap={projectMap}
                                 consultantId={consultantId}
+                                timeEntryTable={timeEntryTable}
                             />
                         );
                     })}


### PR DESCRIPTION
this will fix #81 - when a timestamp is deleted, it should check to see if it is the last timestamp, if so then it will delete time entry. if not, then it will only delete timestamp. If entire project is deleted from timers view, then it will delete time entry as well.