### PR TITLE
Focus traversal

### DIFF
--- a/src/x-esg-week-view/components/RoleDay.js
+++ b/src/x-esg-week-view/components/RoleDay.js
@@ -88,6 +88,13 @@ const RoleDay = ({
         }
     }
 
+    const handleKeyComb = (e) => {
+        if((e.metaKey || e.ctrlKey) && e.key === 'Enter'){
+            console.log(date);
+            console.log(e.target.shadowRoot);
+        }
+    }
+
     return (
         <div className="duration-item">
             <input
@@ -101,6 +108,8 @@ const RoleDay = ({
                 on-blur={(e) => editableInputs && handleBlur(e, entry)}
                 disabled={!editableInputs}
                 placeholder={0}
+                data-date={date}
+                on-keydown={handleKeyComb}
             />
             <div className={`hover-note ${index >= 4 && 'note-reverse'}`}>
                 <textarea

--- a/src/x-esg-week-view/components/RoleDay.js
+++ b/src/x-esg-week-view/components/RoleDay.js
@@ -5,6 +5,7 @@ import {
     getTimeAdjustment,
     getNoteValue,
     isMissingNote,
+    moveVerticalFocus,
  } from "./RoleDayHelpers";
 
 const RoleDay = ({
@@ -88,12 +89,7 @@ const RoleDay = ({
         }
     }
 
-    const handleKeyComb = (e) => {
-        if((e.metaKey || e.ctrlKey) && e.key === 'Enter'){
-            console.log(date);
-            console.log(e.target.shadowRoot);
-        }
-    }
+
 
     return (
         <div className="duration-item">
@@ -109,7 +105,7 @@ const RoleDay = ({
                 disabled={!editableInputs}
                 placeholder={0}
                 data-date={date}
-                on-keydown={handleKeyComb}
+                on-keydown={(e) => moveVerticalFocus(e, date)}
             />
             <div className={`hover-note ${index >= 4 && 'note-reverse'}`}>
                 <textarea
@@ -117,6 +113,8 @@ const RoleDay = ({
                     on-blur={(e) => editableInputs && handleNoteBlur(e, entry)}
                     placeholder={editableInputs ? "Add your notes here..." : "No note recorded"}
                     readonly={!editableInputs}
+                    on-keydown={(e) => moveVerticalFocus(e, date,
+                        ["parentElement", "previousSibling"])}
                 />
             </div>
         </div>

--- a/src/x-esg-week-view/components/RoleDayHelpers.js
+++ b/src/x-esg-week-view/components/RoleDayHelpers.js
@@ -62,3 +62,51 @@ export const isMissingNote = (entry, hours) => {
     if(entry.note) return false;
     return true;
 }
+
+/**
+ * Allows users to cmd/ctrl (+ shift)) + enter to navigate columns
+ * @param {KeyboardEvent} e Keyboard event
+ * @param {string} date string date corresponding to the column
+ * @param {string[]} path Array of strings representing path to the focus target
+ */
+export const moveVerticalFocus = (e, date, path) => {
+    if((e.metaKey || e.ctrlKey) && e.key === 'Enter'){
+        // Go backwards (up) if holding the shift key
+        const increment = e.shiftKey ? -1 : 1;
+
+        // Find the parent of the 'table'
+        const weekContainer = e.path.find(node => {
+            return Array.from(node.classList).includes('week-container');
+        })
+
+        // Query for all inputs for the given date
+        const column = weekContainer.querySelectorAll(`[data-date="${date}"]`);
+
+        // Set current element data so we can track current position
+        let target = e.target;
+        if(path){
+            path.forEach(key => {
+                target = target[key]
+            });
+        }
+        target.dataset.focused = true;
+
+        // Check each element in the column to find current,
+        // then increment and focus
+        for(let i=0; i<column.length; i++){
+            const el = column[i];
+            if(el.dataset.focused === "true"){
+                let newIndex;
+                if(i + increment > column.length - 1){
+                    newIndex = 0;
+                }else if(i + increment < 0){
+                    newIndex = column.length - 1
+                }else{
+                    newIndex = i + increment;
+                }
+                column[newIndex].focus();
+            }
+            column[i].dataset.focused = false;
+        }
+    }
+}

--- a/src/x-esg-week-view/index.js
+++ b/src/x-esg-week-view/index.js
@@ -17,6 +17,7 @@ createCustomElement('x-esg-week-view', {
 		addStages: [],
 		entries: [],
 		timestamps: [],
+		focus: {date: '', psr: ''},
 	},
 	styles,
 	properties: {


### PR DESCRIPTION
Allow users to traverse columns in addition to tabs with keyboard shortcuts (ctrl/cmd + [shift] + enter)